### PR TITLE
Prepare 0.150.4 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,20 @@ members = [
     "crates/*"
 ]
 resolver = "2"
+
+[workspace.package]
+# All the packages in the workspace should have the same version
+version = "0.150.4"
+
+[workspace.dependencies]
+circuit_definitions = { version = "=0.150.4", path = "crates/circuit_definitions" }
+circuit_encodings = { version = "=0.150.4", path = "crates/circuit_encodings" }
+circuit_sequencer_api = { version = "=0.150.4", path = "crates/circuit_sequencer_api" }
+kzg = { version = "=0.150.4", path = "crates/kzg", package = "zksync_kzg" }
+zk_evm = { version = "=0.150.4", path = "crates/zk_evm" }
+zk_evm_abstractions = { version = "=0.150.4", path = "crates/zk_evm_abstractions" }
+zkevm_circuits = { version = "=0.150.4", path = "crates/zkevm_circuits" } 
+zkevm_opcode_defs = { version = "=0.150.4", path = "crates/zkevm_opcode_defs" }
+zkevm_test_harness = { version = "=0.150.4", path = "crates/zkevm_test_harness" }
+zkevm-assembly = { version = "=0.150.4", path = "crates/zkEVM-assembly" }
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,24 @@
+# Release process
+
+If you want to release the packages on crates.io, follow this process:
+
+1. Install `cargo workspaces`: `cargo install cargo-workspaces`
+2. Create a new branch to prepare a release.
+3. Change versions in the `Cargo.toml`:
+  - `version` in `[workspace.package]`
+  - `version` in `[workspace.dependencies]` for all the relevant crates.
+4. Run `cargo build`. It must succeed.
+5. Commit changes.
+6. Run `cargo ws publish --dry-run`. Check the output. It might fail, but it might be OK.
+  - `error: config value 'http.cainfo' is not set` can be ignored.
+  - There might be warnings, this is OK.
+  - There might be errors related to the version resolution, e.g. `failed to select a version`
+    (in particular, for `zkevm_test_harness`). It's due to a bug in cargo workspaces.
+    Check that the packages it complains about actually have the specified version, and if so,
+    it's safe to proceed.
+7. Create a PR named `crates.io: Release <version>`. Get a review and merge it.
+8. From the main branch _after_ you merge it, run `cargo ws publish`.
+9. If something goes wrong, see recommendations below.
+10. If everything is OK, create a tag: `git tag v<version>`, e.g. `git tag v0.150.4`
+11. `git push --tags`
+12. Go to the Releases in the GitHUb, and create a release for published version.

--- a/crates/circuit_definitions/Cargo.toml
+++ b/crates/circuit_definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circuit_definitions"
-version = "0.150.2"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -13,7 +13,7 @@ description = "ZKsync Era circuits definitions"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-circuit_encodings = { version = "0.150.2", path = "../circuit_encodings" }
+circuit_encodings.workspace = true
 snark_wrapper = "=0.1.2"
 
 derivative = "2.2"

--- a/crates/circuit_encodings/Cargo.toml
+++ b/crates/circuit_encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circuit_encodings"
-version = "0.150.2"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -13,8 +13,8 @@ description = "ZKsync Era circuits encodings"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zkevm_circuits = { version = "=0.150.3", path = "../zkevm_circuits" }
-zk_evm = { version = "=0.150.0", path = "../zk_evm" }
+zkevm_circuits.workspace = true
+zk_evm.workspace = true
 
 derivative = "2.2"
 serde = {version = "1", features = ["derive"]}

--- a/crates/circuit_sequencer_api/Cargo.toml
+++ b/crates/circuit_sequencer_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circuit_sequencer_api"
-version = "0.150.2"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -14,7 +14,7 @@ description = "ZKsync Era circuit API for sequencer"
 
 [dependencies]
 
-circuit_encodings = { version = "=0.150.2", path = "../circuit_encodings"}
+circuit_encodings.workspace = true
 bellman = { package = "bellman_ce", version = "=0.7.0" }
 
 

--- a/crates/kzg/Cargo.toml
+++ b/crates/kzg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_kzg"
-version = "0.150.2"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -23,7 +23,7 @@ once_cell = "1"
 serde_with = {version = "1", features = ["hex"]}
 
 boojum = "=0.2.2"
-zkevm_circuits = { version = "=0.150.3", path = "../zkevm_circuits" }
+zkevm_circuits.workspace = true
 
 [dev-dependencies]
 rand = "0.4"

--- a/crates/zkEVM-assembly/Cargo.toml
+++ b/crates/zkEVM-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zkevm-assembly"
-version = "0.150.0"
+version.workspace = true
 authors = ["hedgar2017 <hedgar2017@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -22,5 +22,5 @@ sha3 = "0.10.8"
 num-bigint = "0.4"
 num-traits = "0.2"
 lazy_static = "1.4"
-zkevm_opcode_defs = { version = "=0.150.0", path = "../zkevm_opcode_defs" }
+zkevm_opcode_defs.workspace = true
 smallvec = "1.13"

--- a/crates/zk_evm/Cargo.toml
+++ b/crates/zk_evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zk_evm"
-version = "0.150.0"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -18,7 +18,7 @@ serde_json = "1.0"
 anyhow = "1.0"
 num = { version = "0.4"}
 static_assertions = "1"
-zk_evm_abstractions = { version = "=0.150.0", path = "../zk_evm_abstractions" }
+zk_evm_abstractions.workspace = true
 lazy_static = "1.4"
 
 [dev-dependencies]

--- a/crates/zk_evm_abstractions/Cargo.toml
+++ b/crates/zk_evm_abstractions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zk_evm_abstractions"
-version = "0.150.0"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -18,7 +18,7 @@ serde = { version = "1", features = ["derive"] }
 static_assertions = "1"
 num_enum = "0.6"
 
-zkevm_opcode_defs = { vesion = "=0.150.0", path = "../zkevm_opcode_defs" }
+zkevm_opcode_defs.workspace = true
 
 
 [dev-dependencies]

--- a/crates/zkevm_circuits/Cargo.toml
+++ b/crates/zkevm_circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zkevm_circuits"
-version = "0.150.3"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -27,7 +27,7 @@ rand_new = { package = "rand", version = "0.8" }
 hex = "0.4"
 seq-macro = "0.3"
 
-zkevm_opcode_defs = { version = "=0.150.0", path = "../zkevm_opcode_defs" }
+zkevm_opcode_defs.workspace = true
 cs_derive = "=0.2.2"
 boojum = "=0.2.2"
 

--- a/crates/zkevm_opcode_defs/Cargo.toml
+++ b/crates/zkevm_opcode_defs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zkevm_opcode_defs"
-version = "0.150.0"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/crates/zkevm_test_harness/Cargo.toml
+++ b/crates/zkevm_test_harness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zkevm_test_harness"
-version = "0.150.2"
+version.workspace = true
 edition = "2021"
 authors = ["Alex Vlasov <alex.m.vlasov@gmail.com>", "Konstantin Panarin <kp@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -25,11 +25,11 @@ name = "geometry_config_generator"
 path = "src/geometry_config_generator/main.rs"
 
 [dependencies]
-circuit_definitions = { version = "=0.150.2", path = "../circuit_definitions"}
-circuit_sequencer_api = { version = "=0.150.2", path = "../circuit_sequencer_api"}
-kzg = { package = "zksync_kzg", version = "=0.150.2", path = "../kzg"}
+circuit_definitions.workspace = true
+circuit_sequencer_api.workspace = true
+kzg.workspace = true
 
-zkevm-assembly = { version = "=0.150.0", path = "../zkEVM-assembly" }
+zkevm-assembly.workspace = true
 
 rand = "0.4"
 rayon = "1.10"


### PR DESCRIPTION
- Set the `workspace.version` for every crate, so that it's defined in one place.
- Bump the version to `0.150.4`
- Add `RELEASE.md` with release instructions.