### PR TITLE
chore(ci): Fix release-please workflows

### DIFF
--- a/.github/workflows/release-please-prepare-branch.yml
+++ b/.github/workflows/release-please-prepare-branch.yml
@@ -52,14 +52,9 @@ jobs:
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces
 
-      - name: Extract version from PR title
-        id: extract_version
-        run: |
-          NEW_VERSION=$(echo "${{ github.event.pull_request.title }}" | grep -oP 'v\d+\.\d+\.\d+')
-          echo "version=$NEW_VERSION" >> "$GITHUB_ENV"
-
       - name: Bump version
         run: |
+          NEW_VERSION=$(cat .github/release-please/manifest.json | jq '."."')
           cargo ws version custom $NEW_VERSION --yes --no-git-commit --exact
 
       - name: Push changes

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
             manifest-file: .github/release-please/manifest.json
 
       - name: Show outputs
-        run: echo "${{ toJSON(steps.release.outputs) }}"
+        run: echo "${{ join(steps.release.outputs.*, '\n') }}"
 
   process-release:
     runs-on: [ubuntu-22.04-github-hosted-32core]


### PR DESCRIPTION
- Fix echoing outputs
- Fix extracting version (PR title is not available on `push` trigger, so I'm reading manifest -- it's also safer).