### PR TITLE
chore(ci): Fix release-please workflows #3

### DIFF
--- a/.github/workflows/release-please-prepare-branch.yml
+++ b/.github/workflows/release-please-prepare-branch.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Bump version
         run: |
-          NEW_VERSION=$(cat .github/release-please/manifest.json | jq '."."')
+          NEW_VERSION=$(cat .github/release-please/manifest.json | jq -r '."."')
           cargo ws version custom $NEW_VERSION --yes --no-git-commit --exact
 
       - name: Push changes


### PR DESCRIPTION
Use `jq -r` to remove quotes from version, so that `cargo ws` can parse it.