### PR TITLE
chore: Consistently set meta fields in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,13 @@ resolver = "2"
 [workspace.package]
 # All the packages in the workspace should have the same version
 version = "0.150.4"
+edition = "2021"
+authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
+homepage = "https://zksync.io/"
+repository = "https://github.com/matter-labs/zksync-protocol/"
+license = "MIT OR Apache-2.0"
+keywords = ["blockchain", "zksync"]
+categories = ["cryptography"]
 
 [workspace.dependencies]
 circuit_definitions = { version = "=0.150.4", path = "crates/circuit_definitions" }

--- a/crates/circuit_definitions/Cargo.toml
+++ b/crates/circuit_definitions/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "circuit_definitions"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-zkevm_test_harness/"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync Era circuits definitions"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 circuit_encodings.workspace = true

--- a/crates/circuit_encodings/Cargo.toml
+++ b/crates/circuit_encodings/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "circuit_encodings"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-zkevm_test_harness/"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync Era circuits encodings"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 zkevm_circuits.workspace = true

--- a/crates/circuit_sequencer_api/Cargo.toml
+++ b/crates/circuit_sequencer_api/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "circuit_sequencer_api"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-zkevm_test_harness/"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync Era circuit API for sequencer"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 

--- a/crates/kzg/Cargo.toml
+++ b/crates/kzg/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "zksync_kzg"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-zkevm_test_harness/"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync Era KZG implementation"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/zkEVM-assembly/Cargo.toml
+++ b/crates/zkEVM-assembly/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "zkevm-assembly"
 version.workspace = true
-authors = ["hedgar2017 <hedgar2017@gmail.com>"]
-license = "MIT OR Apache-2.0"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "The zkEVM common utilities"
-repository = "https://github.com/matter-labs/era-zkEVM-assembly"
 
 [[bin]]
 name = "reader"

--- a/crates/zk_evm/Cargo.toml
+++ b/crates/zk_evm/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "zk_evm"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-zk_evm"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync out-of-circuit EraEVM implementation"
-
-resolver = "2"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/zk_evm_abstractions/Cargo.toml
+++ b/crates/zk_evm_abstractions/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "zk_evm_abstractions"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-zk_evm_abstractions"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync EraVM abstractions"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/zkevm_circuits/Cargo.toml
+++ b/crates/zkevm_circuits/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "zkevm_circuits"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-zkevm_circuits"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync Era circuits for EraVM"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 derivative = "2"

--- a/crates/zkevm_opcode_defs/Cargo.toml
+++ b/crates/zkevm_opcode_defs/Cargo.toml
@@ -1,18 +1,14 @@
 [package]
 name = "zkevm_opcode_defs"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-zkevm_opcode_defs"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync EraVM opcode definitions"
-
-resolver = "2"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]
 name = "circuit_pricing_generator"

--- a/crates/zkevm_test_harness/Cargo.toml
+++ b/crates/zkevm_test_harness/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "zkevm_test_harness"
 version.workspace = true
-edition = "2021"
-authors = ["Alex Vlasov <alex.m.vlasov@gmail.com>", "Konstantin Panarin <kp@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-zkevm_test_harness/"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync Era proving utilities"
-
-resolver = "2"
 
 # [[bin]]
 # name = "circuit_limit_estimator"
@@ -50,13 +48,6 @@ regex = { version = "1.10.6", features = ["pattern"] }
 [dev-dependencies]
 rand = "0.4"
 indicatif = "0.16"
-
-[profile.release]
-debug = false
-lto = false
-
-[profile.bench]
-debug = false
 
 [features]
 verbose_circuits = ["circuit_definitions/verbose_circuits", "circuit_sequencer_api/verbose_circuits"]


### PR DESCRIPTION
Set the fields from the workspace `Cargo.toml` and fix the GitHub URLs.