### PR TITLE
fix(zkevm_test_harness): Reduce ExtendedLogQuery RAM usage

### DIFF
--- a/crates/zkevm_test_harness/src/witness/oracle.rs
+++ b/crates/zkevm_test_harness/src/witness/oracle.rs
@@ -235,11 +235,7 @@ fn process_multiplexed_log_queue(
         }
 
         let (query_marker, cycle, query) = match extended_query {
-            ExtendedLogQuery::Query {
-                marker,
-                cycle,
-                query,
-            } => (marker, cycle, query),
+            ExtendedLogQuery::Query(inner) => (inner.marker, inner.cycle, inner.query),
             ExtendedLogQuery::FrameForwardHeadMarker(..) => {
                 continue; // not used
             }


### PR DESCRIPTION
Using Box for big enum variant significantly reduces unnecessary memory usage by the tracer during witgen.