### PR TITLE
feat: Use zeroes instead of simulator states as unused part of RAM permutation witness

### DIFF
--- a/crates/circuit_encodings/src/lib.rs
+++ b/crates/circuit_encodings/src/lib.rs
@@ -592,7 +592,6 @@ impl<
     ) {
         assert!(N % AW == 0);
         let encoding = element.encoding_witness();
-        self.witness.push((encoding, element));
 
         let old_tail = self.tail;
         let mut state = old_tail;

--- a/crates/zkevm_test_harness/src/tests/complex_tests/mod.rs
+++ b/crates/zkevm_test_harness/src/tests/complex_tests/mod.rs
@@ -298,37 +298,6 @@ pub(crate) fn generate_base_layer(
         artifacts_callback,
     );
 
-    let mut unsorted_memory_queue_witnesses_it = unsorted_memory_queue_witnesses.into_iter();
-    let mut sorted_memory_queue_witnesses = sorted_memory_queue_witnesses.into_iter();
-    for el in basic_block_circuits.iter_mut() {
-        use circuit_definitions::boojum::field::Field;
-        match &el {
-            ZkSyncBaseLayerCircuit::RAMPermutation(inner) => {
-                let mut witness = inner.witness.take().unwrap();
-                let zero_state = [GoldilocksField::ZERO; FULL_SPONGE_QUEUE_STATE_WIDTH];
-                witness.sorted_queue_witness = FullStateCircuitQueueRawWitness {
-                    elements: sorted_memory_queue_witnesses
-                        .next()
-                        .unwrap()
-                        .into_iter()
-                        .map(|x| (x, zero_state))
-                        .collect(),
-                };
-                witness.unsorted_queue_witness = FullStateCircuitQueueRawWitness {
-                    elements: unsorted_memory_queue_witnesses_it
-                        .next()
-                        .unwrap()
-                        .into_iter()
-                        .map(|x| (x, zero_state))
-                        .collect(),
-                };
-
-                inner.witness.store(Some(witness));
-            }
-            _ => {}
-        }
-    }
-
     (
         basic_block_circuits,
         recursion_queues,

--- a/crates/zkevm_test_harness/src/tests/run_manually.rs
+++ b/crates/zkevm_test_harness/src/tests/run_manually.rs
@@ -319,36 +319,8 @@ pub(crate) fn run_with_options(entry_point_bytecode: Vec<[u8; 32]>, options: Opt
 
     println!("Simulation and witness creation are completed");
 
-    let mut unsorted_memory_queue_witnesses_it = unsorted_memory_queue_witnesses.into_iter();
-    let mut sorted_memory_queue_witnesses = sorted_memory_queue_witnesses.into_iter();
     for el in basic_block_circuits {
         println!("Doing {} circuit", el.short_description());
-        use circuit_definitions::boojum::field::Field;
-        match &el {
-            ZkSyncBaseLayerCircuit::RAMPermutation(inner) => {
-                let mut witness = inner.witness.take().unwrap();
-                let zero_state = [GoldilocksField::ZERO; FULL_SPONGE_QUEUE_STATE_WIDTH];
-                witness.sorted_queue_witness = FullStateCircuitQueueRawWitness {
-                    elements: sorted_memory_queue_witnesses
-                        .next()
-                        .unwrap()
-                        .into_iter()
-                        .map(|x| (x, zero_state))
-                        .collect(),
-                };
-                witness.unsorted_queue_witness = FullStateCircuitQueueRawWitness {
-                    elements: unsorted_memory_queue_witnesses_it
-                        .next()
-                        .unwrap()
-                        .into_iter()
-                        .map(|x| (x, zero_state))
-                        .collect(),
-                };
-
-                inner.witness.store(Some(witness));
-            }
-            _ => {}
-        }
         base_test_circuit(el);
     }
 

--- a/crates/zkevm_test_harness/src/witness/individual_circuits/memory_related/ram_permutation.rs
+++ b/crates/zkevm_test_harness/src/witness/individual_circuits/memory_related/ram_permutation.rs
@@ -52,7 +52,8 @@ pub(crate) fn compute_ram_circuit_snapshots<CB: FnMut(WitnessGenerationArtifact)
     FirstAndLastCircuitWitness<RamPermutationObservableWitness<Field>>,
     Vec<ClosedFormInputCompactFormWitness<Field>>,
 ) {
-    let total_amount_of_queries = memory_queries.len() + implicit_memory_queries.amount_of_queries();
+    let total_amount_of_queries =
+        memory_queries.len() + implicit_memory_queries.amount_of_queries();
 
     assert_eq!(
         total_amount_of_queries,
@@ -97,13 +98,11 @@ pub(crate) fn compute_ram_circuit_snapshots<CB: FnMut(WitnessGenerationArtifact)
     // since encodings of the elements provide all the information necessary to perform sorting argument,
     // we use them naively
 
-    snapshot_prof("BEFORE SORT");
-
     let all_memory_queries: Vec<&MemoryQuery> = memory_queries
-    .iter()
-    .map(|(_, query)| query)
-    .chain(implicit_memory_queries.iter())
-    .collect();
+        .iter()
+        .map(|(_, query)| query)
+        .chain(implicit_memory_queries.iter())
+        .collect();
 
     use crate::witness::aux_data_structs::per_circuit_accumulator::PerCircuitAccumulator;
     use rayon::prelude::*;
@@ -114,8 +113,6 @@ pub(crate) fn compute_ram_circuit_snapshots<CB: FnMut(WitnessGenerationArtifact)
         Ordering::Equal => a.timestamp.cmp(&b.timestamp),
         a @ _ => a,
     });
-
-    snapshot_prof("AFTER SORT");
 
     assert_eq!(
         memory_queue_simulator.num_items as usize,
@@ -141,8 +138,14 @@ pub(crate) fn compute_ram_circuit_snapshots<CB: FnMut(WitnessGenerationArtifact)
             round_function,
         );
 
-        let lhs_contributions: Vec<_> = all_memory_queries.iter().map(|x| x.encoding_witness()).collect();
-        let rhs_contributions: Vec<_> = all_memory_queries_sorted.iter().map(|x| x.encoding_witness()).collect();
+        let lhs_contributions: Vec<_> = all_memory_queries
+            .iter()
+            .map(|x| x.encoding_witness())
+            .collect();
+        let rhs_contributions: Vec<_> = all_memory_queries_sorted
+            .iter()
+            .map(|x| x.encoding_witness())
+            .collect();
 
         for idx in 0..DEFAULT_NUM_PERMUTATION_ARGUMENT_REPETITIONS {
             let (lhs_grand_product_chain, rhs_grand_product_chain) = compute_grand_product_chains(
@@ -230,13 +233,13 @@ pub(crate) fn compute_ram_circuit_snapshots<CB: FnMut(WitnessGenerationArtifact)
         idx,
         (
             (
-            (
-                ((unsorted_sponge_final_state, sorted_sponge_final_state), lhs_grand_product),
-                rhs_grand_product,
+                (
+                    ((unsorted_sponge_final_state, sorted_sponge_final_state), lhs_grand_product),
+                    rhs_grand_product,
+                ),
+                unsorted_queries_in_chunk,
             ),
-            unsorted_queries_in_chunk,
-        ),
-            sorted_queries_in_chunk
+            sorted_queries_in_chunk,
         ),
     ) in it.enumerate()
     {
@@ -353,10 +356,16 @@ pub(crate) fn compute_ram_circuit_snapshots<CB: FnMut(WitnessGenerationArtifact)
             },
             // we will need witnesses to pop elements from the front of the queue
             unsorted_queue_witness: FullStateCircuitQueueRawWitness {
-                elements: unsorted_queries_in_chunk.into_iter().map(|x| (x.reflect(), [Field::ZERO; FULL_SPONGE_QUEUE_STATE_WIDTH])).collect(),
+                elements: unsorted_queries_in_chunk
+                    .into_iter()
+                    .map(|x| (x.reflect(), [Field::ZERO; FULL_SPONGE_QUEUE_STATE_WIDTH]))
+                    .collect(),
             },
             sorted_queue_witness: FullStateCircuitQueueRawWitness {
-                elements: sorted_queries_in_chunk.into_iter().map(|x| (x.reflect(), [Field::ZERO; FULL_SPONGE_QUEUE_STATE_WIDTH])).collect(),
+                elements: sorted_queries_in_chunk
+                    .into_iter()
+                    .map(|x| (x.reflect(), [Field::ZERO; FULL_SPONGE_QUEUE_STATE_WIDTH]))
+                    .collect(),
             },
         };
 

--- a/crates/zkevm_test_harness/src/witness/oracle.rs
+++ b/crates/zkevm_test_harness/src/witness/oracle.rs
@@ -939,13 +939,9 @@ fn simulate_sorted_memory_queue(
         amount_of_queries,
     );
 
-    let amount_of_ram_circuits = (amount_of_queries as u32 + geometry.cycles_per_ram_permutation
-        - 1)
-        / geometry.cycles_per_ram_permutation;
-
     // the simulation is mostly a sequential computation of hashes
     // for this reason it is one of the slowest parts
-    for (query) in all_memory_queries_sorted.into_iter() {
+    for query in all_memory_queries_sorted.into_iter() {
         let (_, state_witness) = sorted_memory_queries_simulator
             .push_and_output_queue_state_witness(*query, &round_function);
         sorted_memory_queue_states_accumulator.push(state_witness);
@@ -1042,11 +1038,6 @@ fn process_memory_related_circuits<CB: FnMut(WitnessGenerationArtifact)>(
     );
 
     let amount_of_explicit_memory_queries = memory_queries.len();
-    let amount_of_ram_circuits = ((amount_of_explicit_memory_queries
-        + implicit_memory_queries.amount_of_queries()) as u32
-        + geometry.cycles_per_ram_permutation
-        - 1)
-        / geometry.cycles_per_ram_permutation;
 
     // Memory queues simulation is a slowest part in basic witness generation.
     // Each queue simulation is sequential single-threaded computation of hashes.
@@ -1094,10 +1085,8 @@ fn process_memory_related_circuits<CB: FnMut(WitnessGenerationArtifact)>(
         implicit_memory_states,
     ) = unsorted_handle.join().unwrap();
 
-    let (
-        sorted_memory_queue_states_accumulator,
-        sorted_memory_queue_simulator,
-    ) = sorted_handle.join().unwrap();
+    let (sorted_memory_queue_states_accumulator, sorted_memory_queue_simulator) =
+        sorted_handle.join().unwrap();
 
     let memory_artifacts_for_main_vm = MemoryArtifacts {
         memory_queries: Arc::into_inner(memory_queries_arc).unwrap(),
@@ -1215,7 +1204,7 @@ fn process_memory_related_circuits<CB: FnMut(WitnessGenerationArtifact)>(
 
     tracing::debug!("Running secp256r1_simulation simulation");
 
-    let (secp256r1_verify_circuits_data, amount_of_memory_queries) =
+    let (secp256r1_verify_circuits_data, _amount_of_memory_queries) =
         secp256r1_verify_decompose_into_per_circuit_witness(
             amount_of_memory_queries,
             implicit_memory_queries.secp256r1_memory_queries,


### PR DESCRIPTION
Since queue states ([F; SW] part of witness)​​ aren't actually used by RAM permutation circuit, we can remove this RAM-heavy data from witness for this type of circuits.

This PR is first part of this change, which aims to be backwards compatible with current proving subsystem. Another PR that breaks backwards compatibility will contain removal of this field from the RAM witness completely.