### PR TITLE
chore: bump crypto crates to 0.30.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ zkevm_test_harness = { version = "=0.150.7", path = "crates/zkevm_test_harness" 
 zkevm-assembly = { version = "=0.150.7", path = "crates/zkEVM-assembly" }
 
 # `zksync-crypto` repository
-snark_wrapper = "=0.30.1"
-bellman = { package = "zksync_bellman", version = "=0.30.1" }
-boojum = "=0.30.1"
-cs_derive = { package = "zksync_cs_derive", version = "=0.30.1" }
+snark_wrapper = "=0.30.2"
+bellman = { package = "zksync_bellman", version = "=0.30.2" }
+boojum = "=0.30.2"
+cs_derive = { package = "zksync_cs_derive", version = "=0.30.2" }
 


### PR DESCRIPTION
This PR bumps crypto crates to 0.30.2 to include https://github.com/matter-labs/zksync-crypto/pull/31