### PR TITLE
chore: bump crypto crates to 0.30.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ zkevm_test_harness = { version = "=0.150.12", path = "crates/zkevm_test_harness"
 zkevm-assembly = { version = "=0.150.12", path = "crates/zkEVM-assembly" }
 
 # `zksync-crypto` repository
-snark_wrapper = "=0.30.6"
-bellman = { package = "zksync_bellman", version = "=0.30.6" }
-boojum = "=0.30.6"
-cs_derive = { package = "zksync_cs_derive", version = "=0.30.6" }
+snark_wrapper = "=0.30.7"
+bellman = { package = "zksync_bellman", version = "=0.30.7" }
+boojum = "=0.30.7"
+cs_derive = { package = "zksync_cs_derive", version = "=0.30.7" }
 


### PR DESCRIPTION
Release-As: 0.150.13