### PR TITLE
perf(circuit_definitions): adjust proof configs for compression circuits

### DIFF
--- a/crates/circuit_definitions/src/circuit_definitions/aux_layer/compression_modes/mode_4.rs
+++ b/crates/circuit_definitions/src/circuit_definitions/aux_layer/compression_modes/mode_4.rs
@@ -106,7 +106,7 @@ impl ProofCompressionFunction for CompressionMode4 {
 
     fn proof_config_for_compression_step() -> ProofConfig {
         ProofConfig {
-            fri_lde_factor: 2048,
+            fri_lde_factor: 1024,
             merkle_tree_cap_size: 256,
             fri_folding_schedule: None,
             security_level: crate::L1_SECURITY_BITS,

--- a/crates/circuit_definitions/src/circuit_definitions/aux_layer/compression_modes/mode_5_for_wrapper.rs
+++ b/crates/circuit_definitions/src/circuit_definitions/aux_layer/compression_modes/mode_5_for_wrapper.rs
@@ -96,11 +96,11 @@ impl ProofCompressionFunction for CompressionMode5ForWrapper {
 
     fn proof_config_for_compression_step() -> ProofConfig {
         ProofConfig {
-            fri_lde_factor: 4096,
+            fri_lde_factor: 512,
             merkle_tree_cap_size: 8,
             fri_folding_schedule: None,
             security_level: crate::L1_SECURITY_BITS,
-            pow_bits: 8,
+            pow_bits: 26,
         }
     }
 


### PR DESCRIPTION
This PR adjusts proof configs for compression circuits to improve proving speed.
