### PR TITLE
ci: add default gh token permissions to open PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,12 @@
 name: Release
 
+# Give permissions to the release-please to open, update PRs
+# and commit to PRs the repository to update Cargo.lock
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
## What?

* [x] Add default `GITHUB_TOKEN` permissions to open PRs for `release-please` workflow.

## Why?

To be able to use it to open PRs for `release-please` and run tests only with cargo updates.