### PR TITLE
fix(prover): Changed circuit resolver for NodeLayer, Scheduler & RecursionTip

### DIFF
--- a/crates/circuit_definitions/src/circuit_definitions/recursion_layer/mod.rs
+++ b/crates/circuit_definitions/src/circuit_definitions/recursion_layer/mod.rs
@@ -680,7 +680,7 @@ impl ZkSyncRecursiveLayerCircuit {
             Self::SchedulerCircuit(inner) => {
                 let geometry = ZkSyncSchedulerCircuit::geometry();
                 let (max_trace_len, num_vars) = inner.size_hint();
-                let builder_impl = CsReferenceImplementationBuilder::<F, P, ProvingCSConfig>::new(
+                let builder_impl = CsReferenceImplementationBuilder::<F, P, ProvingCSConfig, CR>::new(
                     geometry,
                     max_trace_len.unwrap(),
                 );
@@ -696,7 +696,7 @@ impl ZkSyncRecursiveLayerCircuit {
             Self::NodeLayerCircuit(inner) => {
                 let geometry = ZkSyncNodeLayerRecursiveCircuit::geometry();
                 let (max_trace_len, num_vars) = inner.size_hint();
-                let builder_impl = CsReferenceImplementationBuilder::<F, P, ProvingCSConfig>::new(
+                let builder_impl = CsReferenceImplementationBuilder::<F, P, ProvingCSConfig, CR>::new(
                     geometry,
                     max_trace_len.unwrap(),
                 );
@@ -730,7 +730,7 @@ impl ZkSyncRecursiveLayerCircuit {
             Self::RecursionTipCircuit(inner) => {
                 let geometry = ZkSyncRecursionTipCircuit::geometry();
                 let (max_trace_len, num_vars) = inner.size_hint();
-                let builder_impl = CsReferenceImplementationBuilder::<F, P, ProvingCSConfig>::new(
+                let builder_impl = CsReferenceImplementationBuilder::<F, P, ProvingCSConfig, CR>::new(
                     geometry,
                     max_trace_len.unwrap(),
                 );


### PR DESCRIPTION
What ❔
Changed circuit resolver for NodeLayer, Scheduler & RecursionTip

Why ❔
NodeLayer, Scheduler & RecursionTip were using MtCircuitResolver for no reason. WVG RAM usage for NodeLayer circuit was ~9GB. With the change the circuits of all types use StCircuitResolver, it breaks down RAM usage from ~9GB to ~2GB

Is this a breaking change?
 Yes
 No
Operational changes
Checklist
 PR title corresponds to the body of PR (we generate changelog entries from PRs).
 Tests for the changes have been added / updated.
 Documentation comments have been added / updated.
 Code has been formatted via zkstack dev fmt and zkstack dev lint.