### PR TITLE
feat!: Support new bytecode hash format for 7702 delegation

### DIFF
--- a/crates/zkevm_opcode_defs/src/definitions/versioned_hash/mod.rs
+++ b/crates/zkevm_opcode_defs/src/definitions/versioned_hash/mod.rs
@@ -66,6 +66,7 @@ pub struct BlobSha256Format;
 impl BlobSha256Format {
     pub const CODE_AT_REST_MARKER: u8 = 0;
     pub const YET_CONSTRUCTED_MARKER: u8 = 1;
+    pub const DELEGATION_MARKER: u8 = 2;
 
     pub fn preimage_length_in_bytes(src: &[u8; 32]) -> u16 {
         u16::from_be_bytes([src[2], src[3]])
@@ -110,6 +111,10 @@ impl BlobSha256Format {
     pub fn is_in_construction_if_valid(src: &[u8; VERSIONED_HASH_SIZE]) -> bool {
         src[1] == Self::YET_CONSTRUCTED_MARKER
     }
+
+    pub fn is_delegation_if_valid(src: &[u8; VERSIONED_HASH_SIZE]) -> bool {
+        src[1] == Self::DELEGATION_MARKER
+    }
 }
 
 impl VersionedHashLen32 for BlobSha256Format {
@@ -117,7 +122,9 @@ impl VersionedHashLen32 for BlobSha256Format {
 
     fn is_valid(src: &[u8; 32]) -> bool {
         src[0] == Self::VERSION_BYTE
-            && (src[1] == Self::CODE_AT_REST_MARKER || src[1] == Self::YET_CONSTRUCTED_MARKER)
+            && (src[1] == Self::CODE_AT_REST_MARKER
+                || src[1] == Self::YET_CONSTRUCTED_MARKER
+                || src[1] == Self::DELEGATION_MARKER)
     }
 }
 


### PR DESCRIPTION
This PR adds support for new hash format.
Structure:
- Byte 0 (0x02) means the the account is processed through the EVM interpreter
- Byte 1 (0x02) means that the account is delegated.
- Bytes 2-3 (0x0017) means that the length of the bytecode is 23 bytes.
- Bytes 4-17 have no meaning.
- Bytes 9-11 (0xEF0100) are prefix for the 7702 bytecode of the contract (EF01000 || address).
- Bytes 12-32 are the 20-byte address of the contract.

Changes in EVM only care about byte 1. If bytecode hash starts with `0x0202`, the contract will be masked to either default AA (if called by bootloader) or EVM interpreter (otherwise). Additionally, unlike with "normal" EVM hashes, static context flag is preserved.

⚠️ This PR doesn't have changes in circuits, only out-of-circuit VM is changed.
