### PR TITLE
chore: bumps sha2 to latest 10.9 due to downstream requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3_ce",
  "smallvec",
  "tracing",
@@ -1111,7 +1111,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -1359,7 +1359,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1827,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2522,7 +2522,7 @@ dependencies = [
  "lazy_static",
  "p256",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "zksync_pairing",
 ]

--- a/crates/zkevm_opcode_defs/Cargo.toml
+++ b/crates/zkevm_opcode_defs/Cargo.toml
@@ -22,7 +22,7 @@ zksync_pairing.workspace = true
 bitflags = "2"
 lazy_static = "1.4"
 ethereum-types = "=0.14.1"
-sha2 = "=0.10.8"
+sha2 = "=0.10.9"
 sha3 = "=0.10.8"
 blake2 = "0.10.*"
 k256 = { version = "0.13.*", features = ["arithmetic", "ecdsa"] }


### PR DESCRIPTION
## Description of changes

- Bumps `sha2` dep from 10.8 to latest 10.9 
- Reasoning: `foundry-zksync` does weekly upstream merges from `foundry`. The foundry team recently bumped sha2 to 10.9 disrupting the weekly upstream process for `foundry-zksync`.  