### PR TITLE
fix: Change to bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ zkevm_opcode_defs = { version = "=0.152.6", path = "crates/zkevm_opcode_defs" }
 zkevm_test_harness = { version = "=0.152.6", path = "crates/zkevm_test_harness" }
 zkevm-assembly = { version = "=0.152.6", path = "crates/zkEVM-assembly" }
 
-# `zksync-crypto` repository
+# `zksync-crypto` workspace dependencies
 snark_wrapper = "=0.32.3"
 bellman = { package = "zksync_bellman", version = "=0.32.3" }
 boojum = "=0.32.3"


### PR DESCRIPTION
Version update was done under chore which stops automation from bumping version. This is a minor change to enable automation to create & release new version. The change required is in [this](https://github.com/matter-labs/zksync-protocol/commit/e6b317ceec98fdeab4c88cc23e1749358fc26614) commit.