### PR TITLE
feat: Unpin sha2

### DIFF
--- a/crates/zkevm_opcode_defs/Cargo.toml
+++ b/crates/zkevm_opcode_defs/Cargo.toml
@@ -22,7 +22,7 @@ zksync_pairing.workspace = true
 bitflags = "2"
 lazy_static = "1.4"
 ethereum-types = "=0.14.1"
-sha2 = "=0.10.9"
+sha2 = "0.10"
 sha3 = "=0.10.8"
 blake2 = "0.10.*"
 k256 = { version = "0.13.*", features = ["arithmetic", "ecdsa"] }


### PR DESCRIPTION
This allows building on both 0.10.8 (zksync-era) and 0.10.9 (on zksync-os-server) with zksync-protocol as a dependency.