### PR TITLE
fix(precompiles): drop decimal-string conversions (ecadd prover-DoS + guest soft-float)

### DIFF
--- a/crates/zk_evm_abstractions/src/precompiles/ecadd/airbender_backend.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/ecadd/airbender_backend.rs
@@ -19,12 +19,7 @@ impl ECAddBackend for DelegatedECAddBackend {
         (x1, y1): ECPointCoordinates,
         (x2, y2): ECPointCoordinates,
     ) -> Result<ECPointCoordinates> {
-        if !validate_values_in_field(&[
-            &x1.to_string(),
-            &y1.to_string(),
-            &x2.to_string(),
-            &y2.to_string(),
-        ]) {
+        if !validate_values_in_field(&[x1, y1, x2, y2]) {
             return Err(Error::msg("invalid values"));
         }
 

--- a/crates/zk_evm_abstractions/src/precompiles/ecadd/legacy_backend.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/ecadd/legacy_backend.rs
@@ -20,12 +20,7 @@ impl ECAddBackend for LegacyECAddBackend {
         (x1, y1): ECPointCoordinates,
         (x2, y2): ECPointCoordinates,
     ) -> Result<ECPointCoordinates> {
-        if !validate_values_in_field(&[
-            &x1.to_string(),
-            &y1.to_string(),
-            &x2.to_string(),
-            &y2.to_string(),
-        ]) {
+        if !validate_values_in_field(&[x1, y1, x2, y2]) {
             return Err(Error::msg("invalid values"));
         }
 

--- a/crates/zk_evm_abstractions/src/precompiles/ecmul/airbender_backend.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/ecmul/airbender_backend.rs
@@ -17,7 +17,7 @@ pub(super) struct DelegatedECMulBackend;
 
 impl ECMulBackend for DelegatedECMulBackend {
     fn mul((x1, y1): ECPointCoordinates, scalar: U256) -> Result<ECPointCoordinates> {
-        if !validate_values_in_field(&[&x1.to_string(), &y1.to_string()]) {
+        if !validate_values_in_field(&[x1, y1]) {
             return Err(Error::msg("invalid values"));
         }
 

--- a/crates/zk_evm_abstractions/src/precompiles/ecmul/legacy_backend.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/ecmul/legacy_backend.rs
@@ -18,7 +18,7 @@ pub(super) struct LegacyECMulBackend;
 
 impl ECMulBackend for LegacyECMulBackend {
     fn mul((x1, y1): ECPointCoordinates, s: U256) -> Result<ECPointCoordinates> {
-        if !validate_values_in_field(&[&x1.to_string(), &y1.to_string()]) {
+        if !validate_values_in_field(&[x1, y1]) {
             return Err(Error::msg("invalid values"));
         }
 

--- a/crates/zk_evm_abstractions/src/precompiles/ecpairing/airbender_backend.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/ecpairing/airbender_backend.rs
@@ -36,14 +36,7 @@ impl ECPairingBackend for DelegatedECPairingBackend {
 fn pair_airbender(input: &EcPairingInputTuple) -> Result<AirFq12> {
     let (x1, y1, x2, y2, x3, y3) = (input[0], input[1], input[2], input[3], input[4], input[5]);
 
-    if !validate_values_in_field(&[
-        &x1.to_string(),
-        &y1.to_string(),
-        &x2.to_string(),
-        &y2.to_string(),
-        &x3.to_string(),
-        &y3.to_string(),
-    ]) {
+    if !validate_values_in_field(&[x1, y1, x2, y2, x3, y3]) {
         return Err(Error::msg("invalid values"));
     }
 

--- a/crates/zk_evm_abstractions/src/precompiles/ecpairing/mod.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/ecpairing/mod.rs
@@ -70,14 +70,7 @@ pub(super) fn check_if_in_subgroup(point: G2Affine) -> bool {
 pub fn pair(input: &EcPairingInputTuple) -> Result<Fq12> {
     let (x1, y1, x2, y2, x3, y3) = (input[0], input[1], input[2], input[3], input[4], input[5]);
 
-    if !validate_values_in_field(&[
-        &x1.to_string(),
-        &y1.to_string(),
-        &x2.to_string(),
-        &y2.to_string(),
-        &x3.to_string(),
-        &y3.to_string(),
-    ]) {
+    if !validate_values_in_field(&[x1, y1, x2, y2, x3, y3]) {
         return Err(Error::msg("invalid values"));
     }
 

--- a/crates/zk_evm_abstractions/src/utils/bn254.rs
+++ b/crates/zk_evm_abstractions/src/utils/bn254.rs
@@ -9,6 +9,15 @@ use zkevm_opcode_defs::{
 
 const P: &str = "21888242871839275222246405745257275088696311157297823662689037894645226208583";
 
+/// BN254 base field modulus `P`, as little-endian `u64` limbs. Equality with the
+/// decimal `P` above is asserted in `test::field_modulus_matches_decimal`.
+const FIELD_MODULUS: U256 = U256([
+    0x3c208c16d87cfd47,
+    0x97816a916871ca8d,
+    0xb85045b68181585d,
+    0x30644e72e131a029,
+]);
+
 pub type ECPointCoordinates = (U256, U256);
 
 /// This function converts a [`G1Affine`] point into a tuple of two [`U256`].
@@ -26,15 +35,16 @@ pub fn point_to_u256_tuple(point: G1Affine) -> ECPointCoordinates {
     (x, y)
 }
 
-/// Validate that all the values are less than the modulus.
-pub fn validate_values_in_field(values: &[&str]) -> bool {
-    for value in values {
-        let value = U256::from_str_radix(value, 10).unwrap();
-        if value >= U256::from_str_radix(P, 10).unwrap() {
-            return false;
-        }
-    }
-    true
+/// Validate that all the values are less than the base field modulus.
+///
+/// Takes `U256`s and compares them directly against [`FIELD_MODULUS`]. The
+/// previous signature took decimal `&str`s and callers passed `u256.to_string()`,
+/// so every coordinate incurred a `U256` -> decimal-string -> `U256` round-trip
+/// (~10M guest cycles per call, dominating the precompile) — cheap per erg for
+/// an attacker and a prover-DoS vector. Direct `U256` comparison is a handful of
+/// cycles and involves no string formatting or parsing.
+pub fn validate_values_in_field(values: &[U256]) -> bool {
+    values.iter().all(|value| *value < FIELD_MODULUS)
 }
 
 #[cfg(test)]
@@ -58,5 +68,21 @@ pub mod test {
         let (x, y) = point_to_u256_tuple(point);
         assert_eq!(x, U256::from_str("1").unwrap());
         assert_eq!(y, U256::from_str("2").unwrap());
+    }
+
+    #[test]
+    fn field_modulus_matches_decimal() {
+        use super::*;
+        assert_eq!(FIELD_MODULUS, U256::from_str_radix(P, 10).unwrap());
+    }
+
+    #[test]
+    fn validate_values_in_field_boundary() {
+        use super::*;
+        let modulus = U256::from_str_radix(P, 10).unwrap();
+        assert!(validate_values_in_field(&[U256::zero(), modulus - 1]));
+        assert!(!validate_values_in_field(&[modulus]));
+        assert!(!validate_values_in_field(&[U256::MAX]));
+        assert!(!validate_values_in_field(&[U256::one(), modulus]));
     }
 }

--- a/crates/zk_evm_abstractions/src/utils/bn254.rs
+++ b/crates/zk_evm_abstractions/src/utils/bn254.rs
@@ -7,10 +7,8 @@ use zkevm_opcode_defs::{
     ethereum_types::U256,
 };
 
-const P: &str = "21888242871839275222246405745257275088696311157297823662689037894645226208583";
-
 /// BN254 base field modulus `P`, as little-endian `u64` limbs. Equality with the
-/// decimal `P` above is asserted in `test::field_modulus_matches_decimal`.
+/// decimal modulus is asserted in `test::field_modulus_matches_decimal`.
 const FIELD_MODULUS: U256 = U256([
     0x3c208c16d87cfd47,
     0x97816a916871ca8d,
@@ -49,6 +47,9 @@ pub fn validate_values_in_field(values: &[U256]) -> bool {
 
 #[cfg(test)]
 pub mod test {
+    /// BN254 base field modulus `P` in decimal, used to check [`super::FIELD_MODULUS`].
+    const P: &str = "21888242871839275222246405745257275088696311157297823662689037894645226208583";
+
     /// Verifies that the `point_to_u256_tuple` function returns the correct
     /// values for a point at infinity, that is (0, 0) according to
     /// evm codes spec.


### PR DESCRIPTION
Two related fixes to the precompile hot paths, both removing big-integer/decimal-string round-trips. Built on top of #209 (base `popzxc-airbender-precompiles`); the first commit is already on that branch, so this PR is the second commit.

## 1. ecadd field-membership DoS (`validate_values_in_field`)

`validate_values_in_field` took `&[&str]` and every caller passed `u256.to_string()`, so each coordinate did a `U256 -> decimal string -> U256` round-trip, plus the modulus decimal was re-parsed per value. In the Airbender proving guest this is **~10M cycles per ecadd call** — the curve addition itself is only ~55k — i.e. **~94k cycles per erg** at ecadd's 107-erg price.

An 80M-erg transaction (the per-tx max) can call ecadd ~750k times, forcing **~7.5e12 guest cycles ≈ 118× the ~64B per-proof budget**. The erg price does not bound prover work, so this is a prover-DoS. (ecmul/ecpairing share the check and are affected too.)

Fix: compare `&[U256]` directly against the field modulus (little-endian limbs, asserted equal to the decimal constant by a test). No string work on the hot path; membership semantics unchanged.

Measured (proving guest, delegated backends):

| precompile | before | after | |
|---|---:|---:|---|
| ecadd | 10,058,600 cyc/call | 55,554 | **181×** |
| ecmul | 1,854,319 cyc/call | 585,651 | 3.2× |

ecadd's gas-to-reach-64B rises from ~0.68M to ~123M ergs — above the 80M per-tx limit — closing the DoS.

## 2. Guest soft-float (first commit, already on base)

The delegated BN254 backends built field elements with `AirFq::from_str(value.to_string())`; ark's decimal `from_str` routes through num-bigint's radix parser, whose `f64 log2` buffer sizing linked f64 soft-float intrinsics into the RISC-V proving guest. Switched to `from_be_bytes_mod_order` (identical modular reduction, pure field arithmetic) — the guest now links zero soft-float.

## Tests

All 39 `zk_evm_abstractions` tests pass with `--features airbender-precompile-delegations` (23 without), including the delegated-vs-legacy differential quickchecks for ecadd/ecmul/ecpairing and the new modulus-constant / boundary tests. Precompile outputs are byte-identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)