### PR TITLE
perf(zk_evm_abstractions): optimize the modexp precompile (~38x worst case)

### DIFF
--- a/crates/zk_evm_abstractions/src/precompiles/modexp/airbender_backend.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/modexp/airbender_backend.rs
@@ -67,15 +67,18 @@ fn mul_low(a: &Limbs, b: &Limbs) -> Limbs {
     result
 }
 
+/// High 256 bits of `a * b`.
+fn mul_high(a: &Limbs, b: &Limbs) -> Limbs {
+    let mut result = *a;
+    unsafe {
+        bigint_op_delegation_raw(ptr_mut(&mut result), ptr_const(b), BigIntOps::MulHigh);
+    }
+    result
+}
+
 /// Full 512-bit product of `a * b` as `(low, high)`.
 fn mul_wide(a: &Limbs, b: &Limbs) -> (Limbs, Limbs) {
-    let mut low = *a;
-    let mut high = *a;
-    unsafe {
-        bigint_op_delegation_raw(ptr_mut(&mut low), ptr_const(b), BigIntOps::MulLow);
-        bigint_op_delegation_raw(ptr_mut(&mut high), ptr_const(b), BigIntOps::MulHigh);
-    }
-    (low, high)
+    (mul_low(a, b), mul_high(a, b))
 }
 
 fn ptr_mut(a: &mut Limbs) -> *mut () {
@@ -156,8 +159,8 @@ fn barrett_reduce(y_low: Limbs, y_high: Limbs, m_norm: &Limbs, mu0: &Limbs) -> L
     // q2 = q1 * mu, where mu = 2^256 + mu0. Expanding,
     //   q2 = t_low + (t_high + q1 + q1_high_bit * mu0) * 2^256 + q1_high_bit * 2^512,
     // with (t_low, t_high) = q1_low * mu0. We only need floor(q2 / 2^257),
-    // so t_low is never computed.
-    let (_, t_high) = mul_wide(&q1, mu0);
+    // so t_low is never computed (the `MulLow` delegation is skipped).
+    let t_high = mul_high(&q1, mu0);
     let mut mid = t_high;
     let mut high = q1_high_bit;
     high += add_assign(&mut mid, &q1) as u64;
@@ -185,15 +188,21 @@ fn barrett_reduce(y_low: Limbs, y_high: Limbs, m_norm: &Limbs, mu0: &Limbs) -> L
     debug_assert!(!underflow);
     debug_assert!(r_high.0[0] <= 2 && r_high.0[1..] == [0; 3]);
 
-    // At most two correcting subtractions.
+    // Barrett guarantees r < 3 * m_norm, so at most two correcting
+    // subtractions; the loop is explicitly bounded so a violated invariant
+    // cannot turn it into a long loop in release builds.
     let mut r_extra = r_high.0[0];
-    while r_extra != 0 || is_geq(&r, m_norm) {
+    for _ in 0..2 {
+        if r_extra == 0 && !is_geq(&r, m_norm) {
+            break;
+        }
         let borrow = sub_assign(&mut r, m_norm);
         if borrow {
             debug_assert!(r_extra > 0);
-            r_extra -= 1;
+            r_extra = r_extra.saturating_sub(1);
         }
     }
+    debug_assert!(r_extra == 0 && !is_geq(&r, m_norm));
     r
 }
 

--- a/crates/zk_evm_abstractions/src/precompiles/modexp/airbender_backend.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/modexp/airbender_backend.rs
@@ -32,8 +32,6 @@ use zkevm_opcode_defs::ethereum_types::{U256, U512};
 struct Limbs([u64; 4]);
 
 impl Limbs {
-    const ONE: Self = Self([1, 0, 0, 0]);
-
     fn from_u256(v: U256) -> Self {
         Self(v.0)
     }
@@ -42,6 +40,20 @@ impl Limbs {
         U256(self.0)
     }
 }
+
+// The delegation ABI reinterprets a `&Limbs` as airbender's own 256-bit integer
+// (`airbender_crypto::BigInt<4>`, which is `[u64; 4]` little-endian) and requires
+// 32 LE bytes at a 32-byte-aligned address. Nothing else checks this contract on
+// the riscv32 proving build — the one the prover runs, where the host-side
+// differential tests never execute — so assert the layout at compile time. These
+// arm per-target on both sides of airbender-crypto's cfg split (`ark_ff::BigInt`
+// on host, the `repr(align(32))` fork on riscv32/proving).
+static_assertions::assert_eq_size!(Limbs, airbender_crypto::BigInt<4>);
+static_assertions::const_assert_eq!(core::mem::align_of::<Limbs>(), 32);
+static_assertions::const_assert!(
+    core::mem::align_of::<Limbs>() >= core::mem::align_of::<airbender_crypto::BigInt<4>>()
+);
+static_assertions::const_assert_eq!(core::mem::offset_of!(airbender_crypto::BigInt::<4>, 0), 0);
 
 fn add_assign(a: &mut Limbs, b: &Limbs) -> bool {
     unsafe { bigint_op_delegation_raw(ptr_mut(a), ptr_const(b), BigIntOps::Add) != 0 }
@@ -212,7 +224,13 @@ fn barrett_reduce(y_low: Limbs, y_high: Limbs, m_norm: &Limbs, mu0: &Limbs) -> L
 /// satisfies the `barrett_reduce` precondition.
 fn modmul_shifted(x: &Limbs, y: &Limbs, m_norm: &Limbs, mu0: &Limbs, s: u32) -> Limbs {
     let (p_low, p_high) = mul_wide(x, y);
-    let (y_low, y_high) = shr_512(&p_low, &p_high, s);
+    // For a top-bit-set (crypto-sized) modulus `s == 0`, so the shift is a pure
+    // copy — skip it on the hot path (runs once per modmul).
+    let (y_low, y_high) = if s == 0 {
+        (p_low, p_high)
+    } else {
+        shr_512(&p_low, &p_high, s)
+    };
     barrett_reduce(y_low, y_high, m_norm, mu0)
 }
 
@@ -220,13 +238,25 @@ fn modmul_shifted(x: &Limbs, y: &Limbs, m_norm: &Limbs, mu0: &Limbs, s: u32) -> 
 /// homomorphism onto `mod 2^j`, so the whole exponentiation runs on plain
 /// `MulLow` and the result is masked once at the end.
 fn modexp_pow2(b: U256, e: U256, m: U256) -> U256 {
+    debug_assert!(e >= U256::from(2u64));
     let mask = m - U256::one();
     let base = Limbs::from_u256(b);
-    let mut acc = Limbs::ONE;
-    for i in (0..e.bits()).rev() {
+    // Seed with the base (the top exponent bit always contributes it), then
+    // process the remaining `e.bits() - 1` bits.
+    let mut acc = base;
+    for i in (0..e.bits() - 1).rev() {
         acc = mul_low(&acc, &acc);
+        // The accumulator lives mod 2^256; for an even base it collapses to zero
+        // partway through, after which every MulLow is dead work and the masked
+        // result is zero (`0 & mask == 0`).
+        if acc.0 == [0; 4] {
+            return U256::zero();
+        }
         if e.bit(i) {
             acc = mul_low(&acc, &base);
+            if acc.0 == [0; 4] {
+                return U256::zero();
+            }
         }
     }
     acc.to_u256() & mask
@@ -244,14 +274,26 @@ fn modexp_barrett(b: U256, e: U256, m: U256) -> U256 {
     let mu0 = Limbs([mu.0[0], mu.0[1], mu.0[2], mu.0[3]]);
 
     // base' = (b mod m) << s via a Barrett reduction of b << s. The bound
-    // holds: b·2^s < 2^256·2^s <= 2^256·M since 2^s <= 2^254 < M.
-    let (b_low, b_high) = shl_to_512(&Limbs::from_u256(b), s);
+    // holds: b·2^s < 2^256·2^s <= 2^256·M since 2^s <= 2^254 < M. At s == 0
+    // (top-bit-set modulus) the widening shift is a copy.
+    let (b_low, b_high) = if s == 0 {
+        (Limbs::from_u256(b), Limbs::default())
+    } else {
+        shl_to_512(&Limbs::from_u256(b), s)
+    };
     let base = barrett_reduce(b_low, b_high, &m_norm, &mu0);
 
-    // acc' = 1 << s.
-    let mut acc = Limbs::from_u256(U256::one() << s);
+    // `base` is `(b mod m) << s`, which is zero iff `m | b`; then the result is
+    // zero for every `e >= 1`, so skip the whole loop.
+    if base.0 == [0; 4] {
+        return U256::zero();
+    }
 
-    for i in (0..e.bits()).rev() {
+    // Seed with the base (the top exponent bit always contributes it), then
+    // process the remaining `e.bits() - 1` bits.
+    debug_assert!(e >= U256::from(2u64));
+    let mut acc = base;
+    for i in (0..e.bits() - 1).rev() {
         acc = modmul_shifted(&acc, &acc, &m_norm, &mu0, s);
         if e.bit(i) {
             acc = modmul_shifted(&acc, &base, &m_norm, &mu0, s);
@@ -264,29 +306,9 @@ fn modexp_barrett(b: U256, e: U256, m: U256) -> U256 {
 /// Drop-in replacement for [`super::modexp_inner`] built on the bigint
 /// delegation circuit. Produces bit-identical results.
 pub fn modexp_delegated(b: U256, e: U256, m: U256) -> U256 {
-    // Edge cases mirror `modexp_inner` exactly; see EIP-198.
-    if m.is_zero() {
-        return U256::zero();
-    }
-    if e.is_zero() {
-        return if m == U256::one() {
-            U256::zero()
-        } else {
-            U256::one()
-        };
-    }
-    if e == U256::one() {
-        return b % m;
-    }
-    if b.is_zero() {
-        return U256::zero();
-    }
-    if b == U256::one() {
-        return if m == U256::one() {
-            U256::zero()
-        } else {
-            U256::one()
-        };
+    // EIP-198 edge cases share one implementation with `modexp_inner`.
+    if let Some(result) = super::modexp_edge_case(b, e, m) {
+        return result;
     }
 
     // From here on: m >= 2, e >= 2, b >= 2.

--- a/crates/zk_evm_abstractions/src/precompiles/modexp/airbender_backend.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/modexp/airbender_backend.rs
@@ -1,0 +1,289 @@
+//! Modexp backend that uses the Airbender 256-bit bigint delegation circuit.
+//!
+//! The legacy implementation performs one 512-by-256-bit long division per
+//! squaring/multiplication, which dominates its cost when run inside the
+//! RISC-V proving guest. This backend removes all long division from the
+//! exponentiation loop:
+//!
+//! * The modulus is normalized once per call: `M = m << s` so that the top
+//!   bit of `M` is set, and all intermediate values are kept in the shifted
+//!   domain `v' = v << s`. Since `x·2^s mod M = (x mod m)·2^s`, results
+//!   translate back with a single exact right shift at the end.
+//! * Each modular multiplication is a Barrett reduction with `k = 256`:
+//!   `μ = ⌊2^512 / M⌋` is computed once per call (the only long division),
+//!   and every reduction afterwards is two extra 256×256→512 multiplications
+//!   done by the delegation circuit.
+//! * Power-of-two moduli take a separate path: `mod 2^j` is plain
+//!   truncation, so the whole exponentiation runs modulo `2^256` with
+//!   `MulLow` delegations only and the result is masked at the end.
+//!
+//! The result is bit-identical to `modexp_inner`; the differential tests in
+//! `tests.rs` enforce this.
+
+use airbender_crypto::{
+    bigint_op_delegation_raw, bigint_op_delegation_with_carry_bit_raw, BigIntOps,
+};
+use zkevm_opcode_defs::ethereum_types::{U256, U512};
+
+/// 256-bit value in the layout the bigint delegation circuit expects:
+/// little-endian `u64` limbs at a 32-byte-aligned address.
+#[repr(C, align(32))]
+#[derive(Clone, Copy, Debug, Default)]
+struct Limbs([u64; 4]);
+
+impl Limbs {
+    const ONE: Self = Self([1, 0, 0, 0]);
+
+    fn from_u256(v: U256) -> Self {
+        Self(v.0)
+    }
+
+    fn to_u256(self) -> U256 {
+        U256(self.0)
+    }
+}
+
+fn add_assign(a: &mut Limbs, b: &Limbs) -> bool {
+    unsafe { bigint_op_delegation_raw(ptr_mut(a), ptr_const(b), BigIntOps::Add) != 0 }
+}
+
+fn sub_assign(a: &mut Limbs, b: &Limbs) -> bool {
+    unsafe { bigint_op_delegation_raw(ptr_mut(a), ptr_const(b), BigIntOps::Sub) != 0 }
+}
+
+fn sub_assign_with_borrow(a: &mut Limbs, b: &Limbs, borrow: bool) -> bool {
+    unsafe {
+        bigint_op_delegation_with_carry_bit_raw(ptr_mut(a), ptr_const(b), borrow, BigIntOps::Sub)
+            != 0
+    }
+}
+
+/// Low 256 bits of `a * b`.
+fn mul_low(a: &Limbs, b: &Limbs) -> Limbs {
+    let mut result = *a;
+    unsafe {
+        bigint_op_delegation_raw(ptr_mut(&mut result), ptr_const(b), BigIntOps::MulLow);
+    }
+    result
+}
+
+/// Full 512-bit product of `a * b` as `(low, high)`.
+fn mul_wide(a: &Limbs, b: &Limbs) -> (Limbs, Limbs) {
+    let mut low = *a;
+    let mut high = *a;
+    unsafe {
+        bigint_op_delegation_raw(ptr_mut(&mut low), ptr_const(b), BigIntOps::MulLow);
+        bigint_op_delegation_raw(ptr_mut(&mut high), ptr_const(b), BigIntOps::MulHigh);
+    }
+    (low, high)
+}
+
+fn ptr_mut(a: &mut Limbs) -> *mut () {
+    (a as *mut Limbs).cast()
+}
+
+fn ptr_const(a: &Limbs) -> *const () {
+    (a as *const Limbs).cast()
+}
+
+fn is_geq(a: &Limbs, b: &Limbs) -> bool {
+    for i in (0..4).rev() {
+        if a.0[i] != b.0[i] {
+            return a.0[i] > b.0[i];
+        }
+    }
+    true
+}
+
+/// `(low, high) >> s` of a 512-bit value, `0 <= s <= 255`.
+fn shr_512(low: &Limbs, high: &Limbs, s: u32) -> (Limbs, Limbs) {
+    let src = [
+        low.0[0], low.0[1], low.0[2], low.0[3], high.0[0], high.0[1], high.0[2], high.0[3],
+    ];
+    let word = (s / 64) as usize;
+    let bit = s % 64;
+    let mut out = [0u64; 8];
+    for (i, out_limb) in out.iter_mut().enumerate() {
+        let from = i + word;
+        if from < 8 {
+            let mut v = src[from] >> bit;
+            if bit != 0 && from + 1 < 8 {
+                v |= src[from + 1] << (64 - bit);
+            }
+            *out_limb = v;
+        }
+    }
+    (
+        Limbs([out[0], out[1], out[2], out[3]]),
+        Limbs([out[4], out[5], out[6], out[7]]),
+    )
+}
+
+/// `v << s` widened to 512 bits as `(low, high)`, `0 <= s <= 255`.
+fn shl_to_512(v: &Limbs, s: u32) -> (Limbs, Limbs) {
+    let word = (s / 64) as usize;
+    let bit = s % 64;
+    let mut out = [0u64; 8];
+    for i in (0..8).rev() {
+        if i < word {
+            continue;
+        }
+        let from = i - word;
+        if from < 4 {
+            out[i] = v.0[from] << bit;
+        }
+        if bit != 0 && from >= 1 && from - 1 < 4 {
+            out[i] |= v.0[from - 1] >> (64 - bit);
+        }
+    }
+    (
+        Limbs([out[0], out[1], out[2], out[3]]),
+        Limbs([out[4], out[5], out[6], out[7]]),
+    )
+}
+
+/// Barrett reduction of a 512-bit value `y` modulo the normalized modulus
+/// `m_norm` (top bit set), with `mu0 = ⌊2^512 / m_norm⌋ - 2^256`.
+///
+/// Requires `y < m_norm * 2^256`, which guarantees `q = ⌊y / m_norm⌋` fits
+/// in 256 bits. Returns `y mod m_norm`.
+fn barrett_reduce(y_low: Limbs, y_high: Limbs, m_norm: &Limbs, mu0: &Limbs) -> Limbs {
+    // q1 = y >> 255 < 2^257; its bit 256 is the top bit of `y_high`.
+    let (q1, q1_overflow) = shr_512(&y_low, &y_high, 255);
+    let q1_high_bit = q1_overflow.0[0];
+    debug_assert!(q1_high_bit <= 1 && q1_overflow.0[1..] == [0; 3]);
+
+    // q2 = q1 * mu, where mu = 2^256 + mu0. Expanding,
+    //   q2 = t_low + (t_high + q1 + q1_high_bit * mu0) * 2^256 + q1_high_bit * 2^512,
+    // with (t_low, t_high) = q1_low * mu0. We only need floor(q2 / 2^257),
+    // so t_low is never computed.
+    let (_, t_high) = mul_wide(&q1, mu0);
+    let mut mid = t_high;
+    let mut high = q1_high_bit;
+    high += add_assign(&mut mid, &q1) as u64;
+    if q1_high_bit != 0 {
+        high += add_assign(&mut mid, mu0) as u64;
+    }
+    // q1 < 2 * m_norm and mu <= 2^512 / m_norm give q2 < 2^513, so the part
+    // of q2 above 2^512 is a single bit.
+    debug_assert!(high <= 1);
+
+    // q_hat = floor(q2 / 2^257) = high * 2^255 + (mid >> 1).
+    let q_hat = Limbs([
+        (mid.0[0] >> 1) | (mid.0[1] << 63),
+        (mid.0[1] >> 1) | (mid.0[2] << 63),
+        (mid.0[2] >> 1) | (mid.0[3] << 63),
+        (mid.0[3] >> 1) | (high << 63),
+    ]);
+
+    // r = y - q_hat * m_norm; Barrett guarantees 0 <= r < 3 * m_norm.
+    let (qm_low, qm_high) = mul_wide(&q_hat, m_norm);
+    let mut r = y_low;
+    let borrow = sub_assign(&mut r, &qm_low);
+    let mut r_high = y_high;
+    let underflow = sub_assign_with_borrow(&mut r_high, &qm_high, borrow);
+    debug_assert!(!underflow);
+    debug_assert!(r_high.0[0] <= 2 && r_high.0[1..] == [0; 3]);
+
+    // At most two correcting subtractions.
+    let mut r_extra = r_high.0[0];
+    while r_extra != 0 || is_geq(&r, m_norm) {
+        let borrow = sub_assign(&mut r, m_norm);
+        if borrow {
+            debug_assert!(r_extra > 0);
+            r_extra -= 1;
+        }
+    }
+    r
+}
+
+/// `(x * y) mod m_norm` for values in the shifted domain: `x = a << s`,
+/// `y = b << s` with `a, b < m`. The product is `a·b·2^2s`; shifting right by
+/// `s` (exact, the low `s` bits are zero) yields `a·b·2^s < m·m_norm`, which
+/// satisfies the `barrett_reduce` precondition.
+fn modmul_shifted(x: &Limbs, y: &Limbs, m_norm: &Limbs, mu0: &Limbs, s: u32) -> Limbs {
+    let (p_low, p_high) = mul_wide(x, y);
+    let (y_low, y_high) = shr_512(&p_low, &p_high, s);
+    barrett_reduce(y_low, y_high, m_norm, mu0)
+}
+
+/// `b^e mod 2^j` for `m = 2^j`, `j >= 1`. Truncation modulo `2^256` is a ring
+/// homomorphism onto `mod 2^j`, so the whole exponentiation runs on plain
+/// `MulLow` and the result is masked once at the end.
+fn modexp_pow2(b: U256, e: U256, m: U256) -> U256 {
+    let mask = m - U256::one();
+    let base = Limbs::from_u256(b);
+    let mut acc = Limbs::ONE;
+    for i in (0..e.bits()).rev() {
+        acc = mul_low(&acc, &acc);
+        if e.bit(i) {
+            acc = mul_low(&acc, &base);
+        }
+    }
+    acc.to_u256() & mask
+}
+
+fn modexp_barrett(b: U256, e: U256, m: U256) -> U256 {
+    let s = 256 - m.bits() as u32;
+    let m_shifted = m << s;
+    let m_norm = Limbs::from_u256(m_shifted);
+
+    // mu = ⌊2^512 / M⌋; M is not a power of two here, so ⌊(2^512 - 1) / M⌋
+    // is the same value. This is the only long division in the call.
+    let mu = U512::MAX / U512::from(m_shifted);
+    debug_assert!(mu.0[4] == 1 && mu.0[5..] == [0; 3]);
+    let mu0 = Limbs([mu.0[0], mu.0[1], mu.0[2], mu.0[3]]);
+
+    // base' = (b mod m) << s via a Barrett reduction of b << s. The bound
+    // holds: b·2^s < 2^256·2^s <= 2^256·M since 2^s <= 2^254 < M.
+    let (b_low, b_high) = shl_to_512(&Limbs::from_u256(b), s);
+    let base = barrett_reduce(b_low, b_high, &m_norm, &mu0);
+
+    // acc' = 1 << s.
+    let mut acc = Limbs::from_u256(U256::one() << s);
+
+    for i in (0..e.bits()).rev() {
+        acc = modmul_shifted(&acc, &acc, &m_norm, &mu0, s);
+        if e.bit(i) {
+            acc = modmul_shifted(&acc, &base, &m_norm, &mu0, s);
+        }
+    }
+
+    acc.to_u256() >> s
+}
+
+/// Drop-in replacement for [`super::modexp_inner`] built on the bigint
+/// delegation circuit. Produces bit-identical results.
+pub fn modexp_delegated(b: U256, e: U256, m: U256) -> U256 {
+    // Edge cases mirror `modexp_inner` exactly; see EIP-198.
+    if m.is_zero() {
+        return U256::zero();
+    }
+    if e.is_zero() {
+        return if m == U256::one() {
+            U256::zero()
+        } else {
+            U256::one()
+        };
+    }
+    if e == U256::one() {
+        return b % m;
+    }
+    if b.is_zero() {
+        return U256::zero();
+    }
+    if b == U256::one() {
+        return if m == U256::one() {
+            U256::zero()
+        } else {
+            U256::one()
+        };
+    }
+
+    // From here on: m >= 2, e >= 2, b >= 2.
+    if (m & (m - U256::one())).is_zero() {
+        modexp_pow2(b, e, m)
+    } else {
+        modexp_barrett(b, e, m)
+    }
+}

--- a/crates/zk_evm_abstractions/src/precompiles/modexp/mod.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/modexp/mod.rs
@@ -1,7 +1,26 @@
+use cfg_if::cfg_if;
 use zkevm_opcode_defs::ethereum_types::U256;
 pub use zkevm_opcode_defs::sha2::Digest;
 
 use super::*;
+
+#[cfg(feature = "airbender-precompile-delegations")]
+pub mod airbender_backend;
+#[cfg(test)]
+mod tests;
+
+/// Computes `modexp(b, e, m)` with the fastest implementation available for
+/// the current build configuration. All implementations produce identical
+/// results.
+fn active_modexp(b: U256, e: U256, m: U256) -> U256 {
+    cfg_if! {
+        if #[cfg(feature = "airbender-precompile-delegations")] {
+            airbender_backend::modexp_delegated(b, e, m)
+        } else {
+            modexp_inner(b, e, m)
+        }
+    }
+}
 
 // Base, exponent and modulus
 pub const MEMORY_READS_PER_CYCLE: usize = 3;
@@ -98,7 +117,7 @@ impl<const B: bool> Precompile for ModexpPrecompile<B> {
             read_history.push(m_query);
         }
 
-        let result = modexp_inner(base, exponent, modulus);
+        let result = active_modexp(base, exponent, modulus);
 
         let write_location = MemoryLocation {
             memory_type: MemoryType::Heap, // we default for some value, here it's not that important
@@ -174,7 +193,10 @@ pub fn modexp_inner(b: U256, e: U256, m: U256) -> U256 {
         U256::try_from(rem).unwrap()
     };
 
-    for i in (0..256).rev() {
+    // Iterating from the highest set bit of `e` is equivalent to iterating
+    // from bit 255: while `a == 1`, squaring keeps it at 1 and all skipped
+    // bits are 0, so no multiplications are skipped.
+    for i in (0..e.bits()).rev() {
         let bit = e.bit(i);
         a = modmul(a, a, m);
         if bit {
@@ -194,59 +216,4 @@ pub fn modexp_function<M: Memory, const B: bool>(
 ) {
     let mut processor = ModexpPrecompile::<B>;
     processor.execute_precompile(monotonic_cycle_counter, precompile_call_params, memory)
-}
-
-#[cfg(test)]
-pub mod tests {
-    use std::str::FromStr;
-
-    /// Tests the correctness of the `modexp_inner` function for a specified
-    /// set of inputs from https://www.evm.codes/precompiled#0x05.
-    #[test]
-    fn test_modexp_inner_correctness_evm_codes() {
-        use super::*;
-
-        let b = U256::from_str("0x8").unwrap();
-        let e = U256::from_str("0x9").unwrap();
-        let m = U256::from_str("0xa").unwrap();
-
-        let result = modexp_inner(b, e, m);
-
-        assert_eq!(result, U256::from_str("0x8").unwrap());
-    }
-
-    /// Tests the correctness of the `modexp_inner` function for randomly
-    /// generated U256 integers.
-    #[test]
-    fn test_modexp_inner_correctness_big_ints() {
-        use super::*;
-
-        let b =
-            U256::from_str("0x7f333213268023a7d3d40ea760d0e1c00d5fe99710e379193fc5973e7ad09370")
-                .unwrap();
-        let e = U256::from_str("0x39d71831130091794534336679323390f4408be38cb89963ec41f4a90d6bf63")
-            .unwrap();
-        let m =
-            U256::from_str("0xec6f05ec20e4c25420f9d6bc6800f9544ecabf5dbea80d11e0fb12c7f0517f5b")
-                .unwrap();
-
-        let result = modexp_inner(b, e, m);
-
-        assert_eq!(
-            result,
-            U256::from_str("0x2779a7e4d2b26461c6557a12eb86285eeeb9cf5a40155305177854b15b4ed3df")
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn test() {
-        use super::*;
-
-        let b = U256::from_str("0x05").unwrap();
-        let e = U256::from_str("0x00").unwrap();
-        let m = U256::from_str("0x01").unwrap();
-
-        let result = modexp_inner(b, e, m);
-    }
 }

--- a/crates/zk_evm_abstractions/src/precompiles/modexp/mod.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/modexp/mod.rs
@@ -148,58 +148,68 @@ impl<const B: bool> Precompile for ModexpPrecompile<B> {
     }
 }
 
+/// EIP-198 edge cases shared by `modexp_inner` and the delegated backend so the
+/// two entry points cannot drift. Returns `Some(result)` when the call is fully
+/// determined by an edge case; `None` means the generic square-and-multiply path
+/// must run — and the callers rely on that to guarantee `m >= 2`, `e >= 2`, and
+/// `b >= 2`. In particular the `m == 0` arm is load-bearing: without it the
+/// generic path hits a division by zero / `m - 1` underflow.
+pub(crate) fn modexp_edge_case(b: U256, e: U256, m: U256) -> Option<U256> {
+    // If m = 0, everything is 0.
+    if m.is_zero() {
+        return Some(U256::zero());
+    }
+    // e = 0 => b^0 mod m => generally 1, but if m == 1 => 0
+    if e.is_zero() {
+        return Some(if m == U256::one() {
+            U256::zero()
+        } else {
+            U256::one()
+        });
+    }
+    // e = 1 => b^1 mod m => just b % m
+    if e == U256::one() {
+        return Some(b % m);
+    }
+    // b = 0 => 0^e ( for e>0 ) => 0
+    if b.is_zero() {
+        return Some(U256::zero());
+    }
+    // b = 1 => 1^e => 1 mod m => if m == 1 => 0, else 1
+    if b == U256::one() {
+        return Some(if m == U256::one() {
+            U256::zero()
+        } else {
+            U256::one()
+        });
+    }
+    None
+}
+
 /// This function evaluates the `modexp(b,e,m)`.
 /// It uses the simplest square-and-multiply method that can be found here:
 /// https://cse.buffalo.edu/srds2009/escs2009_submission_Gopal.pdf.
 pub fn modexp_inner(b: U256, e: U256, m: U256) -> U256 {
-    // See EIP-198 for specification
-    // If m = 0, everything is 0.
-    if m.is_zero() {
-        return U256::zero();
-    }
-    // Some edge cases:
-    // e = 0 => b^0 mod m => generally 1, but if m == 1 => 0
-    if e.is_zero() {
-        return if m == U256::one() {
-            U256::zero()
-        } else {
-            U256::one()
-        };
+    if let Some(result) = modexp_edge_case(b, e, m) {
+        return result;
     }
 
-    // e = 1 => b^1 mod m => just b % m
-    if e == U256::one() {
-        return b % m;
-    }
-
-    // b = 0 => 0^e ( for e>0 ) => 0
-    if b.is_zero() {
-        return U256::zero();
-    }
-
-    // b = 1 => 1^e => 1 mod m => if m == 1 => 0, else 1
-    if b == U256::one() {
-        return if m == U256::one() {
-            U256::zero()
-        } else {
-            U256::one()
-        };
-    }
-
-    let mut a = U256::one();
+    // From here on: m >= 2, e >= 2, b >= 2.
+    debug_assert!(e >= U256::from(2u64));
     let modmul = |x: U256, y: U256, m: U256| {
         let product = x.full_mul(y);
         let (_, rem) = product.div_mod(m.into());
         U256::try_from(rem).unwrap()
     };
 
-    // Iterating from the highest set bit of `e` is equivalent to iterating
-    // from bit 255: while `a == 1`, squaring keeps it at 1 and all skipped
-    // bits are 0, so no multiplications are skipped.
-    for i in (0..e.bits()).rev() {
-        let bit = e.bit(i);
+    // Square-and-multiply seeded with the base: the highest set bit of `e` (bit
+    // `e.bits() - 1`) always contributes `1² · b = b`, so we start at `b` and
+    // process the remaining `e.bits() - 1` bits. The seed is the unreduced `b`;
+    // the first modmul reduces it, so the result is unchanged.
+    let mut a = b;
+    for i in (0..e.bits() - 1).rev() {
         a = modmul(a, a, m);
-        if bit {
+        if e.bit(i) {
             a = modmul(a, b, m);
         }
     }

--- a/crates/zk_evm_abstractions/src/precompiles/modexp/tests.rs
+++ b/crates/zk_evm_abstractions/src/precompiles/modexp/tests.rs
@@ -1,0 +1,292 @@
+use std::str::FromStr;
+
+use super::*;
+
+/// Externally computed vectors (Python `pow(b, e, m)`), covering full-width
+/// operands, even moduli, power-of-two moduli, `b >= m`, exponents with
+/// leading zeros and boundary values.
+pub(crate) const MODEXP_VECTORS: &[(&str, &str, &str, &str)] = &[
+    (
+        "0x23b8c1e9392456de3eb13b9046685257bdd640fb06671ad11c80317fa3b1799d",
+        "0x972a846916419f828b9d2434e465e150bd9c66b3ad3c2d6d1a3d1fa7bc8960a9",
+        "0x9a1de644815ef6d13b8faa1837f8a88b17fc695a07a0ca6e0822e8f36c031199",
+        "0x5ac2ad92075b85f4bd4f394b7eeafd348a335b282952b7968d649a462ce9697a",
+    ),
+    (
+        "0x6b65a6a48b8148f6b38a088ca65ed389b74d0fb132e706298fadc1a606cb0fb3",
+        "0xc241330b01a9e71fde8a774bcf36d58b4737819096da1dac72ff5d2a386ecbe0",
+        "0x371ecd7b27cd813047229389571aa8766c307511b2b9437a28df6ec4ce4a2bbd",
+        "0x29316b6d767c123a8065349e26b4e2b6bcb133d7822367de2bbb5b2d19c0d7c5",
+    ),
+    (
+        "0x5be6128e18c267976142ea7d17be31111a2a73ed562b0f79c37459eef50bea63",
+        "0x759cde66bacfb3d00b1f9163ce9ff57f43b7a3a69a8dca03580d7b71d8f56413",
+        "0x4b0dbb418d5288f1142c3fe860e7a113ec1b8ca1f91e1d4c1ff49b7889463e85",
+        "0x07665281e2969a9eb02df6d62c934bf5ec476d7f30da160d2764f1a3d5b2ea2b",
+    ),
+    (
+        "0x3139d32c93cd59bf5c941cf0dc98d2c1e2acf72f9e574f7aa0ee89aed453dd32",
+        "0xfc377a4c4a15544dc5e7ce8a3a578a8ea9488d990bbb259911ce5dd2b45ed1f0",
+        "0x7412b29347294739614ff3d719db3ad0ddd1dfb23b982ef8daf61a26146d3f31",
+        "0x265521d90ddbf01a1cf0b00afee75a1ab916d82ec811412b3be4d0acadf25a56",
+    ),
+    (
+        "0xab9099a435a240ae5af305535ec42e0829a3b2e95d65a441d58842dea2bc372f",
+        "0xa28defe39bf0027312476f57a5e5a5abaefcfad8efc89849b3aa7efe4458a885",
+        "0x451b4cf36123fdf77656af7229d4beef3eabedcbbaa80dd488bd64072bcfbe01",
+        "0x37d9123e0cccdc32cc3d36075639bc25cf35b2bd9284a2463d11a67147ca7c68",
+    ),
+    (
+        "0x5304317faf42e12f3838b3268e944239b02b61c4a3d70628ece66fa2fd5166e6",
+        "0xce177b4e0837b8a3d261a7ab3aa2e4f90e51f30dc6a7ee39c4b032ccd7c524a5",
+        "0x9132b63ef16287e4e9c349e03602f8ac10f1bc81448aaa9e66b2bc5b50c187fc",
+        "0x64bc331427a6f2506f030880ccc63193b0424c4073b4dc5c7e18d532b8dba90c",
+    ),
+    // Small exponent with leading zeros (e = 65537), Mersenne-like odd modulus.
+    (
+        "0x00000000000000000000000000000000000000000000000000000000deadbeef",
+        "0x0000000000000000000000000000000000000000000000000000000000010001",
+        "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed",
+        "0x194f3aafbdd3b89366b97896d401589337afa81c33f13cb1edf34d87f6180549",
+    ),
+    // Tiny operands.
+    (
+        "0x0000000000000000000000000000000000000000000000000000000000000003",
+        "0x0000000000000000000000000000000000000000000000000000000000000002",
+        "0x000000000000000000000000000000000000000000000000000000000000000a",
+        "0x0000000000000000000000000000000000000000000000000000000000000009",
+    ),
+    // All operands at U256::MAX (b == m so the result is 0).
+    (
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+    ),
+    // Base larger than the modulus.
+    (
+        "0x8000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000005",
+        "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe1",
+        "0x0000000000000000000000000000000000000000000000000000000001b4d89f",
+    ),
+    // Power-of-two modulus (2^64).
+    (
+        "0x0000000000000000000000000000000000000000000000000000000000003039",
+        "0x000000000000000000000000000000000000000000000000000000000000ffff",
+        "0x0000000000000000000000000000000000000000000000010000000000000000",
+        "0x000000000000000000000000000000000000000000000000fe76c99806acbe09",
+    ),
+    // Modulus 2 with a huge exponent (top bit set).
+    (
+        "0x0000000000000000000000000000000000000000000000000abcdef123456789",
+        "0x8000000000000000000000000000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000000000000000000000000000002",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+    ),
+    // Largest power-of-two modulus (2^255).
+    (
+        "0x0000000000000000000000000000000000000000000000000000000000000007",
+        "0x0000000000000000000000000000000000000000000000000000000000000064",
+        "0x8000000000000000000000000000000000000000000000000000000000000000",
+        "0x5319d5e494c9a977611d99b7b5cb34b967d4a2c6aecef68933be1fc93d3a1a61",
+    ),
+    // RSA-style: odd modulus, e = 65537.
+    (
+        "0xe27a984d654821d07fcd9eb1a7cad415366eb16f508ebad7b7c93acfe059a0ef",
+        "0x0000000000000000000000000000000000000000000000000000000000010001",
+        "0xbeb799193f22faf823bed01d43cf2fde24933b83757750a9a491f0b2ea1fca65",
+        "0x6a8fa889c57def31a6995d058294303c719d78737819b92f16c526ccddf74ba3",
+    ),
+    // Even (non-power-of-two) modulus, e = 2.
+    (
+        "0x956269f0e5d7b8756dadd6c795a76d79bf3c4c06434308bc89fa6a688fb5d27b",
+        "0x0000000000000000000000000000000000000000000000000000000000000002",
+        "0x7e570ddf04e0a15046d36b09febd3fe1fea17bc8704acf70b957992ecc7e392e",
+        "0x4819c73eb18d760452a89c658bf62af5f4ab2d2ba57eead9d0e7b50174bd94e1",
+    ),
+    // Exponent with many leading zero bytes; sparse odd modulus.
+    (
+        "0x0000000000000000000000000000000000000000000000000000000000000005",
+        "0x00000000000000000000000000000000000000000000000000000000000000ff",
+        "0x0000000000000001000000000000000000000000000000010000000000000007",
+        "0x000000000000000079f0c044150ce85613f2e5c522fbae58be6e3e74e9eed371",
+    ),
+];
+
+fn u256(s: &str) -> U256 {
+    U256::from_str(s).unwrap()
+}
+
+/// Edge cases mandated by EIP-198 semantics, in (b, e, m, expected) form.
+pub(crate) fn edge_cases() -> Vec<(U256, U256, U256, U256)> {
+    let max = U256::MAX;
+    vec![
+        // m == 0 => 0, regardless of anything else.
+        (u256("0x5"), u256("0x5"), U256::zero(), U256::zero()),
+        (max, max, U256::zero(), U256::zero()),
+        // e == 0 => 1, except m == 1 => 0.
+        (u256("0x5"), U256::zero(), U256::one(), U256::zero()),
+        (u256("0x5"), U256::zero(), u256("0x7"), U256::one()),
+        (U256::zero(), U256::zero(), u256("0x7"), U256::one()),
+        // e == 1 => b % m, including b >= m.
+        (u256("0x5"), U256::one(), u256("0x7"), u256("0x5")),
+        (u256("0x9"), U256::one(), u256("0x7"), u256("0x2")),
+        (max, U256::one(), u256("0x2"), U256::one()),
+        // b == 0 => 0 (for e > 0).
+        (U256::zero(), u256("0x5"), u256("0x7"), U256::zero()),
+        (U256::zero(), max, max, U256::zero()),
+        // b == 1 => 1, except m == 1 => 0.
+        (U256::one(), max, u256("0x7"), U256::one()),
+        (U256::one(), max, U256::one(), U256::zero()),
+        // b == m => 0 for e >= 2.
+        (u256("0x7"), u256("0x2"), u256("0x7"), U256::zero()),
+        // m == 2 with even/odd bases.
+        (u256("0x6"), u256("0x3"), u256("0x2"), U256::zero()),
+        (u256("0x7"), u256("0x3"), u256("0x2"), U256::one()),
+        // m == 3 (smallest modulus taking the generic path).
+        (u256("0x5"), u256("0x4"), u256("0x3"), U256::one()),
+        // e == 2 (smallest exponent taking the generic path).
+        (max, u256("0x2"), max - U256::one(), U256::one()),
+    ]
+}
+
+#[test]
+fn modexp_inner_matches_external_vectors() {
+    for (b, e, m, expected) in MODEXP_VECTORS {
+        let result = modexp_inner(u256(b), u256(e), u256(m));
+        assert_eq!(result, u256(expected), "modexp({b}, {e}, {m})");
+    }
+}
+
+#[test]
+fn modexp_inner_handles_edge_cases() {
+    for (b, e, m, expected) in edge_cases() {
+        let result = modexp_inner(b, e, m);
+        assert_eq!(result, expected, "modexp({b}, {e}, {m})");
+    }
+}
+
+/// Tests the correctness of the `modexp_inner` function for a specified
+/// set of inputs from https://www.evm.codes/precompiled#0x05.
+#[test]
+fn test_modexp_inner_correctness_evm_codes() {
+    let b = u256("0x8");
+    let e = u256("0x9");
+    let m = u256("0xa");
+
+    let result = modexp_inner(b, e, m);
+
+    assert_eq!(result, u256("0x8"));
+}
+
+/// Tests the correctness of the `modexp_inner` function for randomly
+/// generated U256 integers.
+#[test]
+fn test_modexp_inner_correctness_big_ints() {
+    let b = u256("0x7f333213268023a7d3d40ea760d0e1c00d5fe99710e379193fc5973e7ad09370");
+    let e = u256("0x39d71831130091794534336679323390f4408be38cb89963ec41f4a90d6bf63");
+    let m = u256("0xec6f05ec20e4c25420f9d6bc6800f9544ecabf5dbea80d11e0fb12c7f0517f5b");
+
+    let result = modexp_inner(b, e, m);
+
+    assert_eq!(
+        result,
+        u256("0x2779a7e4d2b26461c6557a12eb86285eeeb9cf5a40155305177854b15b4ed3df")
+    );
+}
+
+#[test]
+fn test_modexp_inner_trivial_exponent_and_modulus() {
+    let b = u256("0x05");
+    let e = u256("0x00");
+    let m = u256("0x01");
+
+    let result = modexp_inner(b, e, m);
+    assert_eq!(result, U256::zero());
+}
+
+#[cfg(feature = "airbender-precompile-delegations")]
+mod delegated {
+    use super::super::airbender_backend::modexp_delegated;
+    use super::*;
+
+    #[test]
+    fn delegated_modexp_matches_external_vectors() {
+        for (b, e, m, expected) in MODEXP_VECTORS {
+            let result = modexp_delegated(u256(b), u256(e), u256(m));
+            assert_eq!(result, u256(expected), "modexp({b}, {e}, {m})");
+        }
+    }
+
+    #[test]
+    fn delegated_modexp_handles_edge_cases() {
+        for (b, e, m, expected) in edge_cases() {
+            let result = modexp_delegated(b, e, m);
+            assert_eq!(result, expected, "modexp({b}, {e}, {m})");
+        }
+    }
+
+    /// xorshift64* PRNG; deterministic, no external dependencies.
+    struct Rng(u64);
+
+    impl Rng {
+        fn next_u64(&mut self) -> u64 {
+            self.0 ^= self.0 >> 12;
+            self.0 ^= self.0 << 25;
+            self.0 ^= self.0 >> 27;
+            self.0.wrapping_mul(0x2545F4914F6CDD1D)
+        }
+
+        fn next_u256(&mut self) -> U256 {
+            let limbs = [
+                self.next_u64(),
+                self.next_u64(),
+                self.next_u64(),
+                self.next_u64(),
+            ];
+            let mut bytes = [0u8; 32];
+            for (chunk, limb) in bytes.chunks_mut(8).zip(limbs) {
+                chunk.copy_from_slice(&limb.to_le_bytes());
+            }
+            U256::from_little_endian(&bytes)
+        }
+
+        /// Random value with a random bit width, so small and large operands
+        /// (and everything in between) are all exercised.
+        fn next_sized(&mut self) -> U256 {
+            let bits = (self.next_u64() % 257) as usize;
+            if bits == 0 {
+                return U256::zero();
+            }
+            let mask = if bits == 256 {
+                U256::MAX
+            } else {
+                (U256::one() << bits) - U256::one()
+            };
+            self.next_u256() & mask
+        }
+    }
+
+    #[test]
+    fn delegated_modexp_matches_reference_randomized() {
+        let mut rng = Rng(0x243F6A8885A308D3);
+        for case in 0..5_000 {
+            let b = rng.next_sized();
+            let e = rng.next_sized();
+            let mut m = rng.next_sized();
+            // Force interesting modulus shapes on a rotating basis:
+            // odd, even non-power-of-two, power of two, tiny.
+            match case % 4 {
+                0 => m |= U256::one(),
+                1 => m &= !U256::one(),
+                2 => m = U256::one() << (rng.next_u64() % 256) as usize,
+                _ => m = U256::from(rng.next_u64() % 16),
+            }
+
+            let expected = modexp_inner(b, e, m);
+            let actual = modexp_delegated(b, e, m);
+            assert_eq!(actual, expected, "case {case}: modexp({b}, {e}, {m})");
+        }
+    }
+}


### PR DESCRIPTION
# What

Two optimizations to the `modexp` precompile software implementation, both producing **bit-identical results** to the current code:

1. **Exponent-bits-bounded loop** (always on): `modexp_inner` now iterates from the highest set bit of `e` instead of a fixed 256 iterations. The skipped iterations only square `a == 1`, so no observable behavior changes.
2. **Delegated Barrett backend** (behind `airbender-precompile-delegations`): a new `modexp/airbender_backend.rs` runs the square-and-multiply loop on the 256-bit bigint delegation circuit and eliminates long division from the loop entirely:
   - The modulus is normalized once per call (`M = m << s`, top bit set) and all values stay in the shifted domain `v' = v << s`; since `x·2^s mod M = (x mod m)·2^s`, the result converts back with one exact right shift.
   - Each modular multiplication is a Barrett reduction with `k = 256`: `μ = ⌊2^512/M⌋` is computed once per call (the only remaining long division), after which every reduction is two extra delegated 256×256→512 multiplications plus at most two correcting subtractions.
   - Power-of-two moduli bypass Barrett: `mod 2^j` is truncation, so the loop runs on `MulLow` only and masks once at the end.

# Why

The current implementation runs 256 loop iterations unconditionally, each performing a 512÷256-bit Knuth division (~20k of the ~21k cycles per modular multiplication when run in the RISC-V proving guest). A worst-case call costs **~8.1M guest cycles** while being priced at 80,000/17 ≈ 4,705 gas (`Modexp.yul`) — roughly **1,700 prover cycles per gas**, one to two orders of magnitude above the batch average, making modexp an effective prover-DoS lever. After this PR the worst case is ~45 cycles/gas, in line with other precompiles.

# Measurements

Airbender transpiler runner, `record_cycles` around the modexp call; effective = section cycles + 4 × bigint delegations (the `BIGINT_DELEGATION_COEFFICIENT` used by the zksync-os cost model):

| case | before | after (A: bits-bounded) | after (B: delegated) | speedup |
|---|---|---|---|---|
| 256-bit b/e/m | 8,110,629 | 8,101,702 | **213,619** (199,695 + 3,481 del) | ~38× |
| e = 65537 | 631,935 | 380,938 | **33,247** | ~19× |
| e = 2 | 291,758 | 25,146 | **24,810** | ~12× |
| 256-bit, even m | 8,108,829 | — | **213,723** | ~38× |
| m = 2^255 | 552,983 | — | **20,864** | ~26× |

Guest outputs matched the legacy implementation in every measured case.

# Testing

- Pre-refactor safety net: 16 externally computed vectors (Python `pow(b, e, m)`) covering full-width operands, even/power-of-two moduli, `b >= m`, leading-zero exponents, boundary values — plus EIP-198 edge cases (`m ∈ {0,1,2}`, `e ∈ {0,1}`, `b ∈ {0,1}`, `b == m`). These passed before and after the loop-bound change.
- Delegated backend: the same vectors/edge cases, plus **5,000 randomized differential cases** against `modexp_inner` across rotating modulus shapes (odd / even / power-of-two / tiny). Debug asserts validate the Barrett invariants (single-bit `μ` overflow, `q̂` bound, ≤2 correcting subtractions) on every test run.
- `cargo test -p zk_evm_abstractions` green with and without `airbender-precompile-delegations` (23 / 42 tests).
- Integration: the eravm-airbender-verifier guest builds against this branch, and the verifier's `host_runs_batch_native_and_transpiler` integration test (native verification vs. real guest on the transpiler, v31 batch 900065) passes with this change patched in.
- `cargo fmt` + `clippy` clean for the touched files (both feature configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
