### PR TITLE
ci: disable crates.io publishing (git-only airbender-crypto dep)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,4 +23,8 @@ jobs:
       config: '.github/release-please/config.json'     # Specify the path to the configuration file
       manifest: '.github/release-please/manifest.json' # Specify the path to the manifest file
       update-cargo-lock: true                          # Update Cargo.lock file
-      publish-to-crates-io: true                       # Enable publishing to crates.io
+      # Publishing to crates.io is disabled: `zk_evm_abstractions` depends on
+      # `airbender-crypto` via a git dependency (matter-labs/airbender-platform),
+      # which is not published to crates.io, so crates.io publishing is impossible.
+      # release-please still cuts release tags; consumers pin the git tag (e.g. v0.153.13).
+      publish-to-crates-io: false                      # Disabled (git-only airbender-crypto dep)


### PR DESCRIPTION
## Why

`zk_evm_abstractions` depends on `airbender-crypto` via a **git** dependency (`matter-labs/airbender-platform`), which is not published to crates.io. crates.io rejects any crate with a git dependency (even optional/target-gated), so `cargo workspaces publish` fails — this is what broke the 0.153.13 release.

Since `airbender-platform` will not be published, the whole ZK stack moves to **git-tag** dependencies and this workspace stops publishing to crates.io.

## Change

- `release.yaml`: `publish-to-crates-io: false`.

release-please still cuts release tags/changelogs; consumers pin the git tag (e.g. `v0.153.13`). The manual `publish-crates.yaml` (workflow_dispatch) is left as-is.

## Cascade (coordinated PRs)

- **vm2**: pin protocol → tag `v0.153.13`, stop publishing
- **zksync-crypto-gpu**: pin protocol → tag `v0.153.13`, stop publishing
- **zksync-era**: pin protocol (tag), crypto-gpu + vm2 (rev) via git

🤖 Generated with [Claude Code](https://claude.com/claude-code)